### PR TITLE
Disable history mode by default

### DIFF
--- a/src/js/angular-photoswipe.js
+++ b/src/js/angular-photoswipe.js
@@ -172,7 +172,8 @@ ngPhotoSwipe.directive('photoSwipe', [ function () {
 						// otherwise to 1.5x, to make sure that double-tap gesture always zooms image
 						return item.initialZoomLevel < 0.7 ? 1 : 1.5;
 					}
-				}
+				},
+                history: false
 			};
 
 			if(disableAnimation) {


### PR DESCRIPTION
Same issue as reported here: https://github.com/dimsemenov/PhotoSwipe/issues/580

Would you consider disabling history mode until this is resolved?
